### PR TITLE
Updated Default Fallback URL to https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ __pycache__/
 /parts/
 /.cache/
 /.settings/
+.mypy_cache/
 
 # IDE stuff
 .idea/
+
+# Venvs
+.venv/
+venv/
+

--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ For legacy python versions, use ``pypiserver-1.1.x`` series.
 
       --fallback-url FALLBACK_URL
         for packages not found in the local index, this URL will be used to
-        redirect to (default: http://pypi.python.org/simple)
+        redirect to (default: https://pypi.python.org/simple)
 
       --server METHOD
         use METHOD to run the server. Valid values include paste,
@@ -413,10 +413,10 @@ looks like::
     no releases found on pypi for PyXML, Pymacs, mercurial, setuptools
 
     # update raven from 1.4.3 to 1.4.4
-    pip -q install --no-deps  --extra-index-url http://pypi.python.org/simple -d /home/ralf/packages/mirror raven==1.4.4
+    pip -q install --no-deps  --extra-index-url https://pypi.python.org/simple -d /home/ralf/packages/mirror raven==1.4.4
 
     # update greenlet from 0.3.3 to 0.3.4
-    pip -q install --no-deps  --extra-index-url http://pypi.python.org/simple -d /home/ralf/packages/mirror greenlet==0.3.4
+    pip -q install --no-deps  --extra-index-url https://pypi.python.org/simple -d /home/ralf/packages/mirror greenlet==0.3.4
 
 It first prints for each package a single character after checking the
 available versions on pypi. A dot(`.`) means the package is up-to-date, ``'u'``
@@ -811,7 +811,7 @@ See the ``LICENSE.txt`` file.
 
 
 .. _bottle: http://bottlepy.org
-.. _PyPI: http://pypi.python.org
+.. _PyPI: https://pypi.python.org
 .. _twine: https://pypi.python.org/pypi/twine
 .. _pypi-uploader: https://pypi.python.org/pypi/pypi-uploader
 .. _python-pam: https://pypi.python.org/pypi/python-pam/

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -76,7 +76,7 @@ def usage():
 
     --fallback-url FALLBACK_URL
       for packages not found in the local index, this URL will be used to
-      redirect to (default: http://pypi.python.org/simple)
+      redirect to (default: https://pypi.python.org/simple)
 
     --server METHOD
       use METHOD to run the server. Valid values include paste,

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -68,7 +68,7 @@ def configure(**kwds):
             "Could not load welcome-file(%s)!", c.welcome_file, exc_info=1)
 
     if c.fallback_url is None:
-        c.fallback_url = "http://pypi.python.org/simple"
+        c.fallback_url = "https://pypi.python.org/simple"
 
     if c.hash_algo:
         try:

--- a/pypiserver/welcome.html
+++ b/pypiserver/welcome.html
@@ -16,5 +16,5 @@ easy_install -i {{URL}}simple/ PACKAGE
 or via the <a href="{{SIMPLE}}">simple</a> index.</p>
 
 <p>This instance is running version {{VERSION}} of the
-  <a href="http://pypi.python.org/pypi/pypiserver">pypiserver</a> software.</p>
+  <a href="https://pypi.python.org/pypi/pypiserver">pypiserver</a> software.</p>
 </body></html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -178,7 +178,7 @@ def test_fallback(root, _app, testapp):
     assert _app.config.redirect_to_fallback
     resp = testapp.get("/simple/pypiserver/", status=302)
     assert resp.headers[
-        "Location"] == "http://pypi.python.org/simple/pypiserver/"
+        "Location"] == "https://pypi.python.org/simple/pypiserver/"
 
 
 def test_no_fallback(root, _app, testapp):
@@ -313,7 +313,7 @@ def test_root_no_relative_paths(testpriv):
     resp = testpriv.get("/priv/")
     hrefs = [x["href"] for x in resp.html("a")]
     assert hrefs == ['/priv/packages/', '/priv/simple/',
-                     'http://pypi.python.org/pypi/pypiserver']
+                     'https://pypi.python.org/pypi/pypiserver']
 
 
 def test_simple_index_list_no_duplicates(root, testapp):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,14 +80,14 @@ def test_root_r(main):
 
 
 def test_fallback_url(main):
-    main(["--fallback-url", "http://pypi.mirror/simple"])
-    assert main.app.module.config.fallback_url == "http://pypi.mirror/simple"
+    main(["--fallback-url", "https://pypi.mirror/simple"])
+    assert main.app.module.config.fallback_url == "https://pypi.mirror/simple"
 
 
 def test_fallback_url_default(main):
     main([])
     assert main.app.module.config.fallback_url == \
-        "http://pypi.python.org/simple"
+        "https://pypi.python.org/simple"
 
 
 def test_hash_algo_default(main):


### PR DESCRIPTION
@uSpike we can also just merge this commit into your branch, and then that way
we can still use your PR on the official pypiserver branch. This way we will also
have included the discussion on my commit.

----

Due to a pypi API change (reasoning
[here](https://mail.python.org/pipermail/distutils-sig/2017-October/031712.html),
thanks to @natefoo for the link), the redirect links that we were
generating for distributions not present in the package index were
failing with `403` errors.

@ankostis, I have not had time to look into why the standalone tests are
failing. Perhaps we should just ignore them in order to get a new
version out once this is merged to master?